### PR TITLE
Do not start PDF document in full-screen mode

### DIFF
--- a/common/deliverable.sty
+++ b/common/deliverable.sty
@@ -90,7 +90,6 @@
     linkcolor=EUblue,
     filecolor=EUblue,      
     urlcolor=EUblue,
-    pdfpagemode=FullScreen,
 }
 
 % Font and spacing settings


### PR DESCRIPTION
Does anyone feel attached to enable the full-screen mode in the generated PDF? At least in my Linux workflow, I find it annoying that every time I compile the PDF, my reader switches to full-screen mode. 